### PR TITLE
Use BroadcastChannel to Prevent Multiple onSuccess Calls

### DIFF
--- a/src/linkedinCallback.js
+++ b/src/linkedinCallback.js
@@ -27,10 +27,11 @@ export function LinkedInCallback() {
     }
   }
   if (params.code) {
-    window.opener &&
-      window.opener.postMessage(
-        { code: params.code, state: params.state, from: "Linked In" },
-        window.location.origin
-      );
+    const channel = new BroadcastChannel("linkedin_channel");
+    channel.postMessage({
+      code: params.code,
+      state: params.state,
+      from: "Linked In",
+    });
   }
 }

--- a/src/useLinkedIn.js
+++ b/src/useLinkedIn.js
@@ -63,14 +63,6 @@ export function useLinkedIn({
     }
   };
 
-  watchEffect(() => {
-    window.addEventListener("message", receiveMessage, false);
-
-    return () => {
-      window.removeEventListener("message", receiveMessage, false);
-    };
-  });
-
   const getUrl = () => {
     const generatedState = state || generateRandomString();
     localStorage.setItem(LINKEDIN_OAUTH2_STATE, generatedState);
@@ -214,6 +206,16 @@ export function useLinkedIn({
 
     return data;
   };
+
+  onMounted(() => {
+    channel = new BroadcastChannel("linkedin_channel");
+    channel.onmessage = receiveMessage;
+  });
+  onUnmounted(() => {
+    if (channel) {
+      channel.close();
+    }
+  });
 
   return {
     linkedInLogin,


### PR DESCRIPTION
**Description**
This pull request replaces the `window.postMessage` and `message `event listener implementation with the `BroadcastChannel `API for handling inter-context communication. The change addresses an issue where the `onSuccess `function could be called multiple times unexpectedly due to duplicate or redundant event listeners.

**Problem**
Using `window.postMessage` with `message `event listeners can result in multiple, redundant calls to the `onSuccess` function if:
Event listeners are accidentally added more than once.
The same message is processed by overlapping contexts.
This behavior led to unnecessary invocations of the `onSuccess` function, causing potential performance issues and inconsistent application behavior.



**Solution**
The implementation now uses the `BroadcastChannel `API to replace `window.postMessage`:
`BroadcastChannel `ensures scoped communication using a named channel `(linkedin_channel),` reducing the risk of duplicate event handling.
The API simplifies the codebase by eliminating the need for `window.addEventListener` and manual origin checks.
`onmessage` handlers are straightforward and only process messages explicitly sent to the named channel.